### PR TITLE
Add more configuration options for php7

### DIFF
--- a/root/etc/php7/php-fpm.conf
+++ b/root/etc/php7/php-fpm.conf
@@ -5,10 +5,10 @@ error_log = /var/log/php7/error.log
 [www]
 listen = /tmp/php-fpm.sock
 pm = dynamic
-pm.max_children = 15
-pm.start_servers = 2
-pm.min_spare_servers = 1
-pm.max_spare_servers = 6
+pm.max_children = <PM_MAX_CHILDREN>
+pm.start_servers = <PM_START_SERVERS>
+pm.min_spare_servers = <PM_MIN_SPARE_SERVERS>
+pm.max_spare_servers = <PM_MAX_SPARE_SERVERS>
 chdir = /
 request_terminate_timeout = 0
 env[PATH] = /usr/local/bin:/usr/bin:/bin

--- a/root/etc/php7/php-fpm.conf
+++ b/root/etc/php7/php-fpm.conf
@@ -11,6 +11,7 @@ pm.min_spare_servers = <PM_MIN_SPARE_SERVERS>
 pm.max_spare_servers = <PM_MAX_SPARE_SERVERS>
 chdir = /
 request_terminate_timeout = 0
+catch_workers_output = yes
 env[PATH] = /usr/local/bin:/usr/bin:/bin
 php_admin_value[post_max_size] = <UPLOAD_MAX_SIZE>
 php_admin_value[upload_max_filesize] = <UPLOAD_MAX_SIZE>

--- a/root/etc/s6.d/php/run
+++ b/root/etc/s6.d/php/run
@@ -1,6 +1,18 @@
 #!/bin/sh
 echo "\"sed\"ing the php-fpm.conf"
+
+# DEFAULTS
+PM_START_SERVERS=${PM_START_SERVERS:-2}
+PM_MAX_CHILDREN=${PM_MAX_CHILDREN:-15}
+PM_MAX_SPARE_SERVERS=${PM_MAX_SPARE_SERVERS:-6}
+PM_MIN_SPARE_SERVERS=${PM_MIN_SPARE_SERVERS:-1}
+
+
 sed -i -e "s/<UPLOAD_MAX_SIZE>/$UPLOAD_MAX_SIZE/g" /etc/php7/php-fpm.conf \
+       -e "s/<PM_START_SERVERS>/$PM_START_SERVERS/g" /etc/php7/php-fpm.conf \
+       -e "s/<PM_MAX_CHILDREN>/$PM_MAX_CHILDREN/g" /etc/php7/php-fpm.conf \
+       -e "s/<PM_MAX_SPARE_SERVERS>/$PM_MAX_SPARE_SERVERS/g" /etc/php7/php-fpm.conf \
+       -e "s/<PM_MIN_SPARE_SERVERS>/$PM_MIN_SPARE_SERVERS/g" /etc/php7/php-fpm.conf \
        -e "s/<MEMORY_LIMIT>/$MEMORY_LIMIT/g" /etc/php7/php-fpm.conf \
        -e "s/<DISPLAY_ERRORS>/$DISPLAY_ERRORS/g" /etc/php7/php-fpm.conf
 echo "\"chown\"ing the php directories"


### PR DESCRIPTION
Enable logging of php child process stdout/err
Allow four new env vars to be passed and configure the php-fpm.conf