### PR TITLE
chore: disable request logs in caddy

### DIFF
--- a/root/etc/Caddyfile
+++ b/root/etc/Caddyfile
@@ -1,4 +1,3 @@
 :8888 
 root <APPDIR>
 fastcgi / /tmp/php-fpm.sock php
-log stdout


### PR DESCRIPTION
disable request logs in caddy to have request logs all in the same
format, which means haproxy